### PR TITLE
Refactored solr/rr API to use sdk library

### DIFF
--- a/www/api/views/nlc_classify.py
+++ b/www/api/views/nlc_classify.py
@@ -9,7 +9,8 @@ from classified import Classified
 def GetClassifyQuestion(request, sentence):
     natural_language_classifier = NaturalLanguageClassifierV1(
         username=os.environ['watson_username'],
-        password=os.environ['watson_password'])
+        password=os.environ['watson_password']
+    )
     status = natural_language_classifier.status('f5bbbcx175-nlc-1012')
     result = ""
     if status['status'] == 'Available':

--- a/www/api/views/solr.py
+++ b/www/api/views/solr.py
@@ -4,37 +4,32 @@ import os, sys
 import requests
 import re
 from django.http import JsonResponse
+from watson_developer_cloud import RetrieveAndRankV1
 
 def list_clusters(request):
-  url = 'https://gateway.watsonplatform.net/retrieve-and-rank/api/v1/solr_clusters'
-  username = os.environ['watson_rr_username']
-  password = os.environ['watson_rr_password']
-  res = requests.get(url, auth=(username, password))
-  return JsonResponse(res.json())
+  retrieve_and_rank = RetrieveAndRankV1(
+    username=os.environ['watson_rr_username'],
+    password=os.environ['watson_rr_password']
+  )
+  return JsonResponse(retrieve_and_rank.list_solr_clusters())
 
 def list_collections(request, cluster_id):
-  url = 'https://gateway.watsonplatform.net/retrieve-and-rank/api/v1/solr_clusters/' + \
-    cluster_id + '/solr/admin/collections/?action=LIST&wt=json'
-
-  headers = {
-    'Content-Type': 'application/json',
-  }
-  username = os.environ['watson_rr_username']
-  password = os.environ['watson_rr_password']
-  res = requests.post(url, headers=headers, auth=(username, password))
-  return JsonResponse({'collections': res.json()['collections']})
+  retrieve_and_rank = RetrieveAndRankV1(
+    username=os.environ['watson_rr_username'],
+    password=os.environ['watson_rr_password']
+  )
+  return JsonResponse(retrieve_and_rank.list_collections(solr_cluster_id=cluster_id))
 
 def list_configs(request, cluster_id):
-  url = 'https://gateway.watsonplatform.net/retrieve-and-rank/api/v1/solr_clusters/' + cluster_id + '/config'
-  username = os.environ['watson_rr_username']
-  password = os.environ['watson_rr_password']
-  print >> sys.stderr, url
-  res = requests.get(url, auth=(username, password))
-  return JsonResponse({'configs': res.json()['solr_configs']})
+  retrieve_and_rank = RetrieveAndRankV1(
+    username=os.environ['watson_rr_username'],
+    password=os.environ['watson_rr_password']
+  )
+  return JsonResponse(retrieve_and_rank.list_configs(solr_cluster_id=cluster_id))
 
 def list_rankers(request, cluster_id):
-  url = 'https://gateway.watsonplatform.net/retrieve-and-rank/api/v1/rankers'
-  username = os.environ['watson_rr_username']
-  password = os.environ['watson_rr_password']
-  res = requests.get(url, headers=headers, auth=(username, password))
-  return JsonResponse({'rankers': res.json()['rankers']})
+  retrieve_and_rank = RetrieveAndRankV1(
+    username=os.environ['watson_rr_username'],
+    password=os.environ['watson_rr_password']
+  )
+  return JsonResponse(retrieve_and_rank.list_rankers())


### PR DESCRIPTION
Refactored API to use the `watson_development_cloud` module instead of 

Helpful links:
https://github.com/watson-developer-cloud/python-sdk/blob/master/watson_developer_cloud/retrieve_and_rank_v1.py

https://github.com/watson-developer-cloud/python-sdk/blob/master/examples/retrieve_and_rank_v1.py